### PR TITLE
Fix command for adding ports in ComposeNormalizer

### DIFF
--- a/src/modules/ComposeNormalizer.js
+++ b/src/modules/ComposeNormalizer.js
@@ -130,7 +130,7 @@ export default {
       output += _.map(
         serviceOptions.ports,
         (port) =>
-          `dokku proxy:ports-add ${generatedServiceName} http:${port.host}:${port.container}\n`
+          `dokku ports:add ${generatedServiceName} http:${port.host}:${port.container}\n`
       ).join("");
     }
 


### PR DESCRIPTION
proxy:ports-add is no longer supported syntax with dokku, updated to working syntax

closes #2 